### PR TITLE
Compatibility with Qt 6.8

### DIFF
--- a/.qmake.conf
+++ b/.qmake.conf
@@ -1,7 +1,6 @@
-load(qt_build_config)
 CONFIG += warning_clean
 
 QT_SOURCE_TREE = $$PWD
 QT_BUILD_TREE = $$shadowed($$PWD)
 
-MODULE_VERSION = 5.11.1
+MODULE_VERSION = 6.8.0

--- a/sqlitecipher.pro
+++ b/sqlitecipher.pro
@@ -6,6 +6,7 @@ android {
     TEMPLATE = lib
 }
 
+QT += core core-private sql sql-private
 QT_FOR_CONFIG += sqldrivers-private
 
 CONFIG += c++11 plugin
@@ -42,12 +43,8 @@ OTHER_FILES += $$PWD/src/SqliteCipherDriverPlugin.json
     QMAKE_CXXFLAGS *= $$QT_CFLAGS_SQLITE
 }
 
-QT = core core-private sql-private
-
 PLUGIN_CLASS_NAME = SqliteCipherDriverPlugin
 PLUGIN_TYPE = sqldrivers
-
-load(qt_plugin)
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 

--- a/src/sqlite3/sqlite3.pri
+++ b/src/sqlite3/sqlite3.pri
@@ -37,6 +37,13 @@ android-g++ {
 win32-g++ {
     DEFINES += restrict=__restrict
 }
+unix:!macx {
+    DEFINES += restrict=__restrict__
+}
+
+!defined(restrict) {
+    DEFINES += restrict=
+}
 
 INCLUDEPATH += $$PWD
 DEPENDPATH  += $$PWD


### PR DESCRIPTION
This pull request includes several changes to update the configuration and build settings for the project. The most important changes include updating the module version, adjusting the Qt dependencies, and modifying compiler definitions for different platforms.

### Configuration Updates:
* Updated the `MODULE_VERSION` from `5.11.1` to `6.8.0` in `.qmake.conf`.

### Compiler Definitions:
* Added platform-specific `restrict` definitions for `unix` systems in `src/sqlite3/sqlite3.pri`.